### PR TITLE
Make PHP router work easily with built-in php test server 

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -54,4 +54,9 @@ get('/callback/$name/$last_name', function($name, $last_name){
 // For GET or POST
 // The 404.php which is inside the views folder will be called
 // The 404.php has access to $_GET and $_POST
-any('/404','views/404.php');
+if (php_sapi_name() != 'cli-server') {
+  any('/404','views/404.php');
+} else {
+  // If the built-in PHP testserver is used, don't show 404 page otherwise files will not be shown.
+  return false;
+}


### PR DESCRIPTION
The simplest way to test a PHP application is to use the built-in PHP Server. It works quite well, but it needs to know if the router script didn't find a result and if it needs to check for a file. This works by not echoing anything and returning false.

Easiest way is to change this in the routes.php file. You could add a check if a file exists or not to make the 404 page work if needed.
```

if (php_sapi_name() != 'cli-server') {
    any('/404','views/404.php');
} else {
    return false;
}
```

`php -S 127.0.0.1:8000 routes.php`



Edit: If the routes capture destinations where files exist, then this won't work.
Alternatively placing the following at the beginning of routes.php would help. 
This might need more input sanitization before it can be used:
```

if (php_sapi_name() === 'cli-server') {
    $fileName = __DIR__.parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
    if (file_exists($fileName) && !is_dir($fileName)) return false;
}

```